### PR TITLE
added send email notification feat with SendGrid

### DIFF
--- a/lib/api/notification/NotificationService.ts
+++ b/lib/api/notification/NotificationService.ts
@@ -1,17 +1,19 @@
-import Twilio from "twilio";
 import sgMail from '@sendgrid/mail';
-import SendGrid from "@sendgrid/client";
+import Twilio from "twilio";
 import { NotificationHandler, NotificationRequest } from "types/notification";
 
 
 export class NotificationService implements NotificationHandler{
     twilioClient: Twilio.Twilio;
-    sgClient: SendGrid.Client;
+    sgMail: typeof sgMail;
 
     constructor() {
+        if(!process.env.SENDGRID_API_KEY || !process.env.TWILIO_ACCOUNT_SID || !process.env.TWILIO_AUTH_TOKEN){
+            throw new Error('Missing environment variables');
+        }
         this.twilioClient = Twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
-        sgMail.setApiKey(process.env.SENDGRID_API_KEY || '');
-        sgMail.setClient(this.sgClient);
+        this.sgMail = sgMail;
+        this.sgMail.setApiKey(process.env.SENDGRID_API_KEY);
     }
 
     async sendNotification(notification: NotificationRequest): Promise<void> {
@@ -37,7 +39,7 @@ export class NotificationService implements NotificationHandler{
     }
 
     async sendEmail(notification: NotificationRequest): Promise<void> {
-        sgMail
+        this.sgMail
         .send({
             to: notification.receivers[0].payload,
             from: 'nftaddresstracker@gmail.com',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sd-track-nft-transactions",
       "version": "0.1.0",
       "dependencies": {
+        "@sendgrid/mail": "^7.7.0",
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.9",
         "eslint": "8.28.0",
@@ -1428,6 +1429,41 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
     },
+    "node_modules/@sendgrid/client": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.7.0.tgz",
+      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
+      "dependencies": {
+        "@sendgrid/helpers": "^7.7.0",
+        "axios": "^0.26.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.7.0.tgz",
+      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.7.0.tgz",
+      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
+      "dependencies": {
+        "@sendgrid/client": "^7.7.0",
+        "@sendgrid/helpers": "^7.7.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -2591,7 +2627,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8013,6 +8048,32 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
     },
+    "@sendgrid/client": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.7.0.tgz",
+      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
+      "requires": {
+        "@sendgrid/helpers": "^7.7.0",
+        "axios": "^0.26.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.7.0.tgz",
+      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.7.0.tgz",
+      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
+      "requires": {
+        "@sendgrid/client": "^7.7.0",
+        "@sendgrid/helpers": "^7.7.0"
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -8863,8 +8924,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-lazy-prop": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@sendgrid/client": "^7.7.0",
     "@sendgrid/mail": "^7.7.0",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",


### PR DESCRIPTION
Created send email function to notify user via email whenever an NFT is transferred from specified ethereum address. Also created parent function to call sendEmail or sendSMS depending on receiverType (EMAIL or SMS). 

Ref: [SendGrid API](https://docs.sendgrid.com/for-developers/sending-email)